### PR TITLE
Padding, effectively providing a silence / counterpoint shunt

### DIFF
--- a/src/Mutate4l/Cli/Lexer.cs
+++ b/src/Mutate4l/Cli/Lexer.cs
@@ -30,7 +30,7 @@ namespace Mutate4l.Cli
             { "legato", Legato }, { "leg", Legato },
             { "mask", Mask},
             { "monophonize", Monophonize }, { "mono", Monophonize },
-            { "prepad", PrePad }, { "pp", PrePad },
+            { "padding", Padding }, { "pad", Padding },  { "p", Padding },
             { "quantize", Quantize }, { "qnt", Quantize },
             { "ratchet", Ratchet }, { "rat", Ratchet },
             { "relength", Relength }, { "relen", Relength },

--- a/src/Mutate4l/Cli/Lexer.cs
+++ b/src/Mutate4l/Cli/Lexer.cs
@@ -30,6 +30,7 @@ namespace Mutate4l.Cli
             { "legato", Legato }, { "leg", Legato },
             { "mask", Mask},
             { "monophonize", Monophonize }, { "mono", Monophonize },
+            { "prepad", PrePad }, { "pp", PrePad },
             { "quantize", Quantize }, { "qnt", Quantize },
             { "ratchet", Ratchet }, { "rat", Ratchet },
             { "relength", Relength }, { "relen", Relength },

--- a/src/Mutate4l/Cli/TokenType.cs
+++ b/src/Mutate4l/Cli/TokenType.cs
@@ -17,7 +17,7 @@
         Legato,
         Mask,
         Monophonize,
-        PrePad,
+        Padding,
         Quantize,
         Ratchet,
         Relength,

--- a/src/Mutate4l/Cli/TokenType.cs
+++ b/src/Mutate4l/Cli/TokenType.cs
@@ -17,6 +17,7 @@
         Legato,
         Mask,
         Monophonize,
+        PrePad,
         Quantize,
         Ratchet,
         Relength,

--- a/src/Mutate4l/ClipProcessor.cs
+++ b/src/Mutate4l/ClipProcessor.cs
@@ -90,6 +90,9 @@ namespace Mutate4l
                 case TokenType.Monophonize:
                     resultContainer = Monophonize.Apply(clips);
                     break;
+                case TokenType.PrePad:
+                    resultContainer = PrePad.Apply(command, clips);
+                    break;
                 case TokenType.Quantize:
                     resultContainer = Quantize.Apply(command, clips);
                     break;

--- a/src/Mutate4l/ClipProcessor.cs
+++ b/src/Mutate4l/ClipProcessor.cs
@@ -90,8 +90,8 @@ namespace Mutate4l
                 case TokenType.Monophonize:
                     resultContainer = Monophonize.Apply(clips);
                     break;
-                case TokenType.PrePad:
-                    resultContainer = PrePad.Apply(command, clips);
+                case TokenType.Padding:
+                    resultContainer = Padding.Apply(command, clips);
                     break;
                 case TokenType.Quantize:
                     resultContainer = Quantize.Apply(command, clips);

--- a/src/Mutate4l/Commands/Padding.cs
+++ b/src/Mutate4l/Commands/Padding.cs
@@ -5,18 +5,19 @@ using Mutate4l.Utility;
 namespace Mutate4l.Commands
 {
     // Extracts notes of the current clips and inserts nothing in front, effectively padding them. 
-    public class PrePadOptions
+    // An optional second argument enforces an abritrary total duration;
+    public class PaddingOptions
     {
         [OptionInfo(type: OptionType.Default, 1/2f)]
-        public decimal[] Lengths { get; set; } = { 1 };
+        public decimal[] Lengths { get; set; } = { 2 };
     }
 
-    // # desc: Prepads a clip with the desired length.
-    public static class PrePad
+    // # desc: Prepads a clip with the desired length. Optionally with an abritrary total duration.
+    public static class Padding
     {
         public static ProcessResultArray<Clip> Apply(Command command, params Clip[] clips)
         {
-            (var success, var msg) = OptionParser.TryParseOptions(command, out PrePadOptions options);
+            (var success, var msg) = OptionParser.TryParseOptions(command, out PaddingOptions options);
             if (!success)
             {
                 return new ProcessResultArray<Clip>(msg);
@@ -24,27 +25,21 @@ namespace Mutate4l.Commands
             return Apply(options, clips);
         }
 
-        public static ProcessResultArray<Clip> Apply(PrePadOptions options, params Clip[] clips)
+        public static ProcessResultArray<Clip> Apply(PaddingOptions options, params Clip[] clips)
         {
-            var processedClips = new Clip[clips.Length];
-           
+            var processedClips = new Clip[clips.Length];         
             var i = 0;
-
             foreach (var clip in clips)
-
             {
-                var duration = options.Lengths[0] + clip.Length;
-
+                var duration = options.Lengths.Length > 1 ? options.Lengths[1] : options.Lengths[0] + clip.Length;
                 var processedClip = new Clip(duration, clip.IsLooping);
+  
+                processedClip.Notes.AddRange(ClipUtilities.GetSplitNotesInRangeAtPosition(0, duration, clip.Notes, 0));
 
-                System.Collections.Generic.List<NoteEvent> Tempnotes = ClipUtilities.GetSplitNotesInRangeAtPosition(0, duration, clip.Notes, 0);
-
-                foreach (var item in Tempnotes)
+                foreach (var item in processedClip.Notes)
                 {
                     item.Start += options.Lengths[0];
                 }
-
-                processedClip.Notes.AddRange(Tempnotes);
                 processedClips[i++] = processedClip;
             }
             return new ProcessResultArray<Clip>(processedClips);

--- a/src/Mutate4l/Commands/PrePad.cs
+++ b/src/Mutate4l/Commands/PrePad.cs
@@ -4,14 +4,14 @@ using Mutate4l.Utility;
 
 namespace Mutate4l.Commands
 {
-    // Extracts a region of the current clips, effectively cropping them. If two params, start - duration is used, otherwise 0 - duration.
+    // Extracts notes of the current clips and inserts nothing in front, effectively padding them. 
     public class PrePadOptions
     {
         [OptionInfo(type: OptionType.Default, 1/2f)]
         public decimal[] Lengths { get; set; } = { 1 };
     }
 
-    // # desc: Crops a clip to the desired length, or within the desired region.
+    // # desc: Prepads a clip with the desired length.
     public static class PrePad
     {
         public static ProcessResultArray<Clip> Apply(Command command, params Clip[] clips)

--- a/src/Mutate4l/Commands/PrePad.cs
+++ b/src/Mutate4l/Commands/PrePad.cs
@@ -1,0 +1,53 @@
+﻿using Mutate4l.Cli;
+using Mutate4l.Core;
+using Mutate4l.Utility;
+
+namespace Mutate4l.Commands
+{
+    // Extracts a region of the current clips, effectively cropping them. If two params, start - duration is used, otherwise 0 - duration.
+    public class PrePadOptions
+    {
+        [OptionInfo(type: OptionType.Default, 1/2f)]
+        public decimal[] Lengths { get; set; } = { 1 };
+    }
+
+    // # desc: Crops a clip to the desired length, or within the desired region.
+    public static class PrePad
+    {
+        public static ProcessResultArray<Clip> Apply(Command command, params Clip[] clips)
+        {
+            (var success, var msg) = OptionParser.TryParseOptions(command, out PrePadOptions options);
+            if (!success)
+            {
+                return new ProcessResultArray<Clip>(msg);
+            }
+            return Apply(options, clips);
+        }
+
+        public static ProcessResultArray<Clip> Apply(PrePadOptions options, params Clip[] clips)
+        {
+            var processedClips = new Clip[clips.Length];
+           
+            var i = 0;
+
+            foreach (var clip in clips)
+
+            {
+                var duration = options.Lengths[0] + clip.Length;
+
+                var processedClip = new Clip(duration, clip.IsLooping);
+
+                System.Collections.Generic.List<NoteEvent> Tempnotes = ClipUtilities.GetSplitNotesInRangeAtPosition(0, duration, clip.Notes, 0);
+
+                foreach (var item in Tempnotes)
+                {
+                    item.Start += options.Lengths[0];
+                }
+
+                processedClip.Notes.AddRange(Tempnotes);
+                processedClips[i++] = processedClip;
+            }
+            return new ProcessResultArray<Clip>(processedClips);
+        }
+    }
+}


### PR DESCRIPTION
This should allow for the creation of counterpoint beats and sectional positioning within reason.

PrePad null space before extant clip info, when chained will blank start of result.